### PR TITLE
sending api_key through http header with basic authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,23 +3,21 @@ var ini = require('ini');
 var http = require('http');
 var https = require('https');
 var util = require('util');
+var url = require('url');
 
 function getProtocolURIPort(end_point) {
   var mapping = {};
-  var uri_port = [];
-  if (end_point.toLowerCase().indexOf("http://") === 0) {
+  parsed_url = url.parse(end_point);
+  if (parsed_url.protocol === "http:") {
     mapping["protocol"] = "HTTP";
-    uri_port = end_point.substring(7).split(":");
-  } else if (end_point.toLowerCase().indexOf("https://") === 0) {
+  } else if (parsed_url.protocol === "https:") {
     mapping["protocol"] = "HTTPS";
-    uri_port = end_point.substring(8).split(":");
-  
   } else {
     throw new Error("Error: end_point " + end_point + " does not contain a protocol (HTTP/HTTPS).");
   }
-  mapping["uri"] = uri_port[0];
-  if(uri_port.length > 1) {
-    mapping["port"] = Number(uri_port[1]);
+  mapping["uri"] = parsed_url.hostname;
+  if(parsed_url.port !== 'null') {
+    mapping["port"] = Number(parsed_url.port);
   }
 
   return mapping;
@@ -111,9 +109,9 @@ PredictiveServiceClient.prototype.query = function(po_name, data, callback) {
   }.bind(this);
 
   if (this.schema == -1) { 
-    this.setSchema(schema_callback)
+    this.setSchema(schema_callback);
   } else {
-    this._query(po_name, data, callback);
+    schema_callback(null);
   }
 }
 
@@ -152,7 +150,7 @@ PredictiveServiceClient.prototype.feedback = function(request_id, data, callback
   if (this.schema == -1) { 
     this.setSchema(schema_callback)
   } else {
-    this._feedback(request_id, data, callback);
+    schema_callback(null);
   }
 }
 

--- a/sampleCode.js
+++ b/sampleCode.js
@@ -3,11 +3,8 @@ http.createServer(function (req, res) {
     res.writeHead(200, {'Content-Type': 'text/plain'});
     var PredictiveServiceClient = require('dato-predictive-service-client');
     
-    var end_point = "https://ping-test-ps-one-seven-five-1093788135.us-west-2.elb.amazonaws.com"
-    var api_key = "3616490c-3d5a-4391-a261-5618339ccfb2"
-    
-    //var end_point = "http://localhost:9005"
-    //var api_key = "api_key"
+    var end_point = "http://localhost:9005"
+    var api_key = "api_key"
 
     var client = new PredictiveServiceClient(end_point,api_key);
     client.setShouldVerifyCertificate(false);

--- a/sampleCode.js
+++ b/sampleCode.js
@@ -1,0 +1,34 @@
+var http = require('http');
+http.createServer(function (req, res) {
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    var PredictiveServiceClient = require('dato-predictive-service-client');
+    
+    var end_point = "https://ping-test-ps-one-seven-five-1093788135.us-west-2.elb.amazonaws.com"
+    var api_key = "3616490c-3d5a-4391-a261-5618339ccfb2"
+    
+    //var end_point = "http://localhost:9005"
+    //var api_key = "api_key"
+
+    var client = new PredictiveServiceClient(end_point,api_key);
+    client.setShouldVerifyCertificate(false);
+    console.log(client);
+    var data = {'a':1,'b':2}
+    var uuid = ""
+    client.query('add', data, function(err, resp) {
+        if (err != null) {
+          throw new Error(err);          
+        } else {
+          console.log(resp.statusCode); // status code of the response
+          console.log(resp.data); // response data
+
+          var feedback_data = {'result':'correct'};
+          client.feedback(resp.data.uuid, feedback_data, function(err, resp) {
+            console.log(resp);
+          });
+        }
+    });
+    
+
+    res.end("Thanks for contacting me!");
+}).listen(3000, '127.0.0.1');
+console.log('Server running at http://127.0.0.1:3000/');


### PR DESCRIPTION
because of the asynchronous nature of the NodeJs we have to refactor query() and feedback() modules as follow:

def feedback(...) {  
  def schema_callback = function(erro) {
     _feedback(...); 
  }
  if (schema is not set) { 
    setSchema(schema_callback)
   } else {
     _feedback(...);
   }
 }
def _feedback() { 
   //implements the feedback logic ... 
}

query() follows the same pattern. Basically we now have a wrapper called feedback() that first checks if schema is set. If NOT, will set the schema and then calls _feedback() ... 
